### PR TITLE
CMP0074 is known since CMAKE 3.12, add missing include in SubSamples.h

### DIFF
--- a/Base/include/SubSamples.h
+++ b/Base/include/SubSamples.h
@@ -20,6 +20,7 @@
 
 #include <utility>
 #include <vector>
+#include <algorithm>
 #include <iostream>
 
 #include "Rtypes.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0048 NEW)
-cmake_policy(SET CMP0074 NEW)
+
+if("${CMAKE_VERSION}" VERSION_GREATER "3.12.0")
+    cmake_policy(SET CMP0074 NEW)
+endif()
 project(flow VERSION 2.0 LANGUAGES CXX)
 
 if (APPLE)


### PR DESCRIPTION
Fix compilation issues.

